### PR TITLE
Fix/flash of unstyled content #44

### DIFF
--- a/public/css/global.css
+++ b/public/css/global.css
@@ -62,13 +62,8 @@ html.lenis body {
 }
 
 body {
-    /* opacity: 0; */
-    line-height: 1;
-    /* visibility: hidden; */
-    /* animation: fade-in .4s forwards; */
-    /* overflow: hidden; */
+    /* line-height: 1; */
     scrollbar-width: none;
-    /* Verbergt de scrollbar */
 }
 
 @keyframes fade-in {

--- a/src/components/molecules/Hero.astro
+++ b/src/components/molecules/Hero.astro
@@ -82,7 +82,7 @@
     @keyframes heroIntro {
         0% {
             opacity: 0;
-            transform: translateY(1em);
+            transform: translateY(50px);
         }
         100% {
             opacity: 1;
@@ -95,26 +95,26 @@
         position: absolute;
         font-weight: bold;
         top: -0px;
-        animation: rotateWord 10s cubic-bezier(0.25, 0.46, 0.45, 0.94) infinite
+        animation: rotateWord 10.26s cubic-bezier(0.25, 0.46, 0.45, 0.94) infinite
             both;
         animation-delay: 0.26s;
         will-change: transform, opacity;
     }
 
     .rotator-word:nth-child(2) {
-        animation-delay: 2.5s;
+        animation-delay: 2.76s;
     }
     .rotator-word:nth-child(3) {
-        animation-delay: 5s;
+        animation-delay: 5.26s;
     }
     .rotator-word:nth-child(4) {
-        animation-delay: 7.5s;
+        animation-delay: 7.76s;
     }
 
     @keyframes rotateWord {
         0% {
             opacity: 0;
-            transform: translateY(1em);
+            transform: translateY(50px);
         }
         6% {
             opacity: 1;
@@ -128,12 +128,12 @@
 
         27% {
             opacity: 0;
-            transform: translateY(-1em);
+            transform: translateY(-50px);
         }
 
         100% {
             opacity: 0;
-            transform: translateY(-1em);
+            transform: translateY(-50px);
         }
     }
 
@@ -142,6 +142,9 @@
         font-size: 16px;
         margin-top: clamp(2rem, 16vh, 14rem);
         line-height: 1.4;
+        opacity: 0;
+        animation: heroIntro 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+        animation-delay: .32s;
     }
 
     .contact-button {
@@ -156,6 +159,9 @@
         background-size: 300%;
         transition: background-position 0.6s;
         background-image: linear-gradient(90deg, #3a6caa 50%, #facc15 50%);
+        opacity: 0;
+        animation: heroIntro 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+        animation-delay: .38s;
     }
 
     .contact-button:hover {
@@ -165,6 +171,9 @@
 
     small {
         margin-top: 12px;
+        opacity: 0;
+        animation: heroIntro 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+        animation-delay: .44s;
     }
 
     small a {
@@ -190,7 +199,7 @@
 
     @media (prefers-reduced-motion: reduce) {
         .hero-title-static,
-        .rotator-word {
+        .rotator-word, p, .contact-button, small {
             animation: none;
             opacity: 1;
             transform: none;

--- a/src/components/molecules/Hero.astro
+++ b/src/components/molecules/Hero.astro
@@ -1,9 +1,14 @@
 <section class="hero">
     <div class="content">
-        <h1 class="hero-title">
-            <div class="hero-title-static">Wij maken</div><br />
+        <h1 class="hero-title" aria-label="Wij maken websites, designs, ai-agents en content">
+            <span class="hero-title-static-wrapper">
+                <div class="hero-title-static">Wij maken</div>
+            </span>
             <span class="rotator-wrapper">
                 <span class="rotator-word">websites</span>
+                <span class="rotator-word">designs</span>
+                <span class="rotator-word">ai-agents</span>
+                <span class="rotator-word">content</span>
             </span>
         </h1>
 
@@ -51,27 +56,85 @@
         line-height: 1;
     }
 
-    /* .hero-title-static {
-        background: linear-gradient(
-            90deg,
-            var(--quarternary-color) 0%,
-            var(--primary-color)
-        );
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
-        text-fill-color: transparent;
-    } */
-
-    :global(.line-wrapper-title) {
+    .hero-title-static-wrapper {
+        display: flex;
         position: relative;
-        clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+        height: 1em;
+        overflow: hidden;
     }
 
-    :global(.line) {
-        display: inline-block;
-        transform: translateY(115px);
-        transition: transform 0.5s ease-out;
+    .hero-title-static {
+        width: 100%;
+        animation: heroIntro 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+        animation-delay: 0.2s;
+        opacity: 0;
+        will-change: transform, opacity;
+    }
+
+    .rotator-wrapper {
+        position: relative;
+        display: flex;
+        height: 1em;
+        overflow: hidden;
+        vertical-align: middle;
+    }
+
+    @keyframes heroIntro {
+        0% {
+            opacity: 0;
+            transform: translateY(1em);
+        }
+        100% {
+            opacity: 1;
+            transform: translateY(0);
+        }
+    }
+
+    .rotator-word {
+        width: 100%;
+        position: absolute;
+        font-weight: bold;
+        top: -0px;
+        animation: rotateWord 10s cubic-bezier(0.25, 0.46, 0.45, 0.94) infinite
+            both;
+        animation-delay: 0.26s;
+        will-change: transform, opacity;
+    }
+
+    .rotator-word:nth-child(2) {
+        animation-delay: 2.5s;
+    }
+    .rotator-word:nth-child(3) {
+        animation-delay: 5s;
+    }
+    .rotator-word:nth-child(4) {
+        animation-delay: 7.5s;
+    }
+
+    @keyframes rotateWord {
+        0% {
+            opacity: 0;
+            transform: translateY(1em);
+        }
+        6% {
+            opacity: 1;
+            transform: translateY(0);
+        }
+
+        22% {
+            opacity: 1;
+            transform: translateY(0);
+        }
+
+        27% {
+            opacity: 0;
+            transform: translateY(-1em);
+        }
+
+        100% {
+            opacity: 0;
+            transform: translateY(-1em);
+        }
     }
 
     p {
@@ -82,7 +145,6 @@
     }
 
     .contact-button {
-        /* background-color: var(--tertiary-color); */
         color: var(--light-color);
         padding: 10px 20px;
         font-size: 20px;
@@ -126,26 +188,23 @@
         transition: all 0.2s cubic-bezier(0.445, 0.05, 0.55, 0.95);
     }
 
-    /* Rotator styles */
-    .rotator-wrapper {
-        position: relative;
-        display: flex;
-        height: 1em; /* Houdt dezelfde hoogte als de tekst */
-        overflow: hidden;
-        vertical-align: middle;
-    }
+    @media (prefers-reduced-motion: reduce) {
+        .hero-title-static,
+        .rotator-word {
+            animation: none;
+            opacity: 1;
+            transform: none;
+        }
 
-    .rotator-word {
-        width: 100%;
-        /* background: linear-gradient(
-            90deg,
-            var(--quarternary-color),
-            var(--primary-color)
-        );
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
-        text-fill-color: transparent; */
+        .rotator-word:nth-child(2) {
+            display: none;
+        }
+        .rotator-word:nth-child(3) {
+            display: none;
+        }
+        .rotator-word:nth-child(4) {
+            display: none;
+        }
     }
 
     @media screen and (min-width: 540px) {
@@ -199,95 +258,3 @@
         }
     }
 </style>
-
-<script is:inline>
-    window.addEventListener("DOMContentLoaded", () => {
-        const prefersReducedMotion = window.matchMedia(
-            "(prefers-reduced-motion: reduce)",
-        ).matches;
-
-        const words = ["websites", "ai agents", "designs", "content"];
-        const rotatorWord = document.querySelector(".rotator-word");
-
-        let index = 0;
-
-        const animateWords = () => {
-            const nextIndex = (index + 1) % words.length;
-
-            gsap.to(rotatorWord, {
-                y: "-100%",
-                opacity: 0,
-                duration: 0.5,
-                ease: "power2.in",
-                onComplete: () => {
-                    rotatorWord.textContent = words[nextIndex];
-                    gsap.set(rotatorWord, { y: "100%" });
-
-                    gsap.to(rotatorWord, {
-                        y: "0%",
-                        opacity: 1,
-                        duration: 0.5,
-                        ease: "power2.out",
-                    });
-
-                    index = nextIndex;
-                },
-            });
-        };
-
-        if (!prefersReducedMotion) {
-            setInterval(animateWords, 2000);
-
-            const animatingTitle = new window.SplitType(".hero-title", {
-                types: "lines, words",
-                lineClass: "line",
-            });
-
-            animatingTitle.lines.forEach((line) => {
-                const wrapper = document.createElement("div");
-                wrapper.classList.add("line-wrapper-title");
-                line.parentNode.insertBefore(wrapper, line);
-                wrapper.appendChild(line);
-            });
-
-            gsap.fromTo(
-                ".line",
-                { y: 115 },
-                {
-                    y: 0,
-                    stagger: 0.1,
-                    duration: 0.3,
-                    ease: "power4.out",
-                },
-            );
-
-            gsap.from("p, .content .contact-button, small", {
-                y: 30,
-                opacity: 0,
-                stagger: 0.2,
-                duration: 0.8,
-                ease: "power2.out",
-                delay: 0.3,
-            });
-        } else {
-            // Geen animatie: toon gewoon eerste woord direct
-            rotatorWord.textContent = words[0];
-        }
-
-        // Smooth scroll is UI enhancement, laat gerust aan
-        document.querySelectorAll('a[href^="#"]').forEach((anchor) => {
-            anchor.addEventListener("click", function (e) {
-                e.preventDefault();
-                const targetElement = document.querySelector(
-                    this.getAttribute("href"),
-                );
-                if (targetElement) {
-                    window.scrollTo({
-                        top: targetElement.offsetTop,
-                        behavior: "smooth",
-                    });
-                }
-            });
-        });
-    });
-</script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -30,8 +30,10 @@ const structuredDataString = JSON.stringify(
 		<meta name="viewport" content="width=device-width" />
 		<meta name="description" content={description} />
 		<title>{title}</title>
-		
-		<!-- JSON-LD voor gestructureerde data -->
+		<script>
+			document.documentElement.classList.add("js");
+		</script>
+
 		<script type="application/ld+json" set:html={structuredDataString} />
 
 		<link rel="stylesheet" href="/css/global.css" />


### PR DESCRIPTION
## What does this change?
 
I've removed all GSAP animations in the ```Hero.astro``` component and replaced it with CSS animations.
I've created 2 simple keyframes. One for rotating the words and one for the sliding up effect.
Because there is no GSAP being loaded the FOUC isn't showing anymore.
 
 
## How Has This Been Tested?
 
- [ ] User test
- [x] Accessibility test
- [x] Performance test
- [x] Responsive Design test
- [x] Device test
- [x] Browser test
 
## Images

###Lighthouse test/Performance & a11y
<img width="1335" height="531" alt="Screenshot 2025-08-19 at 10 02 53" src="https://github.com/user-attachments/assets/ccac50a3-a020-446a-a4e7-e728eed2af51" />

### Browser test

I've tested on Safari, Chrome and Firefox. None of them experienced the FOUC.

### Device test/Responsive Design

 I've tested on my own mobile device and didn't experience FOUC.
I also tested viewports in the browser and didn't see any weird changes to the UI.
 
## How to review
 
Open the URL: https://brixdev.netlify.app and see if you notice any flash of content before the animation starts.
