### PR TITLE
fix: responsive font sizes

### DIFF
--- a/public/css/global.css
+++ b/public/css/global.css
@@ -38,7 +38,6 @@
 }
 
 html {
-    /* overflow-x: hidden; */
     background-color: var(--light-color);
     color: var(--dark-color);
     scroll-behavior: smooth;
@@ -62,7 +61,6 @@ html.lenis body {
 }
 
 body {
-    /* line-height: 1; */
     scrollbar-width: none;
 }
 
@@ -83,9 +81,38 @@ body::-webkit-scrollbar {
 }
 
 h1,
-h2 {
+h2,
+h3,
+h4 {
     font-family: "Midnight", sans-serif;
     text-transform: uppercase;
+}
+
+h1 {
+    font-size: clamp(2.5rem, 8.5vw + 1rem, 10rem);
+}
+
+h2 {
+    font-size: clamp(2rem, 5.5vw + 1rem, 8rem);
+}
+
+h3 {
+    font-size: clamp(1.5rem, 3vw + 1rem, 5rem);
+}
+
+h4 {
+    font-size: clamp(2rem, 4vw + 1rem, 3rem);
+}
+
+h5 {
+    font-size: clamp(1.5rem, 2.5vw + 1rem, 1.875rem);
+}
+
+p {
+    font-size: clamp(1rem, .8vw + 0.875rem, 1.375rem);
+    line-height: 1.4;
+    font-family: "JetBrains", sans-serif;
+    max-width: 1000px;
 }
 
 a {
@@ -100,17 +127,17 @@ button {
     color: inherit;
 }
 
-  .squircle {
+.squircle {
     border-radius: 16px;
-  }
+}
 
-  .has-squircle .squircle {
-      -webkit-mask-image: paint(squircle);
-      mask-image: paint(squircle);
-      border-radius: 0;
-      --squircle-radius: 14px;
-      --squircle-smooth: 1;
-    }
+.has-squircle .squircle {
+    -webkit-mask-image: paint(squircle);
+    mask-image: paint(squircle);
+    border-radius: 0;
+    --squircle-radius: 14px;
+    --squircle-smooth: 1;
+}
 
 :focus {
     outline: 2px solid #FACC15;

--- a/src/components/molecules/CardsStack.astro
+++ b/src/components/molecules/CardsStack.astro
@@ -7,13 +7,13 @@ import ContentSvg from "@atoms/ContentSVG.astro";
 
 <div class="cards-container">
     <div class="scroll-cards">
-        <h1>Onze diensten</h1>
+        <h2>Onze diensten</h2>
         <article class="scroll-cards__item" tabindex="0">
             <div class="scroll-card-image">
                 <WebsiteSvg />
             </div>
             <div class="scroll-card-text">
-                <h2>Websites</h2>
+                <h3>Websites</h3>
                 <p>
                     Wij ontwikkelen razendsnelle, moderne websites die perfect
                     aansluiten op jouw merkidentiteit. Altijd responsive,
@@ -28,9 +28,9 @@ import ContentSvg from "@atoms/ContentSVG.astro";
                 <ToolsSvg />
             </div>
             <div class="scroll-card-text">
-                <h2>AI agents</h2>
+                <h3>AI agents</h3>
                 <p>
-                    Bespaar tijd op contentcreatie zonder in te leveren op kwaliteit. Onze AI Agents leren jouw unieke toon en stijl, en passen deze toe op social media, e-mails en SEO‑blogs. Geautomatiseerd en past perfect bij uw merk. Zo focust jouw team zich op groei en kwaliteit, niet op repetitieve taken.
+                    Bespaar tijd op contentcreatie zonder in te leveren op kwaliteit. Onze AI Agents leren jouw unieke toon en stijl, en passen deze toe op social media, e-mails en SEO‑blogs. Zo focust jouw team zich op groei en kwaliteit, niet op repetitieve taken.
                 </p>   
             </div>
         </article>
@@ -39,7 +39,7 @@ import ContentSvg from "@atoms/ContentSVG.astro";
                 <DesignSvg />
             </div>
             <div class="scroll-card-text">
-                <h2>Designs</h2>
+                <h3>Designs</h3>
                 <p>
                     We ontwerpen sterke, mobile-first designs die werken op elk
                     schermformaat. Elk ontwerp is helder, functioneel en zorgt
@@ -53,10 +53,10 @@ import ContentSvg from "@atoms/ContentSVG.astro";
                 <ContentSvg />
             </div>
             <div class="scroll-card-text">
-                <h2>Content</h2>
+                <h3>Content</h3>
             <p>
                 Goede content valt op én voelt vertrouwd. We sturen een ervaren
-                fotograaf langs om foto- en videocontent te maken die perfect
+                fotograaf langs om foto- en videocontent te maken wat
                 past bij jouw merk en website. Daarnaast schrijven we heldere,
                 overtuigende teksten die je verhaal versterken en de bezoeker
                 meenemen met jouw bedrijf.
@@ -90,37 +90,35 @@ import ContentSvg from "@atoms/ContentSVG.astro";
         margin-top: 40vh;
     }
 
-    .scroll-cards h1 {
+    .scroll-cards h2 {
         text-align: center;
         position: sticky;
-        top: 80px;
-        font-size: 36px;
+        top: 150px;
+        color: var(--light-color);
     }
 
     .scroll-cards__item {
         --offset: 20px;
         color: #000;
         position: sticky;
-        top: 175px;
-        /* top: max(26vh, 14em); */
-        margin-top: 60px;
+        top: 120px;
+        margin-top: 400px;
         padding: 32px 24px;
         height: 480px;
         background: #fff;
         box-shadow: 0 2px 40px rgba(0, 0, 0, 0.1);
-        /* width: calc(100% - 4 * var(--offset)); */
         border-radius: 12px;
     }
 
-    h2 {
-        font-size: 24px;
+    h3 {
         text-transform: uppercase;
         padding: 16px 0;
         margin: 0;
     }
 
-    p {
-        font-size: 16px;
+    .scroll-card-text p {
+        font-family: 'Inter', sans-serif;
+        font-size: clamp(0.75rem, .8vw + 0.75rem, 1.75rem);
         line-height: 1.5;
     }
 
@@ -144,21 +142,9 @@ import ContentSvg from "@atoms/ContentSVG.astro";
         .scroll-cards__item {
             padding: 48px 36px;
         }
-
-        h2 {
-            font-size: 28px;
-        }
-
-        p {
-            font-size: 18px;
-        }
     }
 
     @media screen and (min-width: 768px) {
-        .scroll-cards h1 {
-            font-size: 42px;
-        }
-
         .scroll-cards__item {
             display: flex;
             flex-direction: row;
@@ -168,12 +154,11 @@ import ContentSvg from "@atoms/ContentSVG.astro";
 
         .scroll-card-text {
             max-width: 60%;
-            padding-left: 36px;
+            padding-left: 48px;
         }
 
-        h2 {
+        h3 {
             padding-top: 0;
-            font-size: 32px;
         }
 
         p {
@@ -193,28 +178,18 @@ import ContentSvg from "@atoms/ContentSVG.astro";
 
 
     @media screen and (min-width: 928px) {
-        .scroll-cards h1 {
-            top: 120px;
-            font-size: 48px;
+        .scroll-cards h2 {
+            top: 250px;
         }
 
         .scroll-cards__item {
             --offset: 25px;
             height: 400px;
-            top: 225px;
+            top: 140px;
         }
 
         .scroll-card-text {
             max-width: 60%;
-            padding-left: 36px;
-        }
-
-        h2 {
-            font-size: 36px;
-        }
-
-        p {
-            font-size: 20px;
         }
     }
 
@@ -237,21 +212,9 @@ import ContentSvg from "@atoms/ContentSVG.astro";
             height: 450px;
         }
 
-        .scroll-cards h1 {
-            font-size: 60px;
-        }
-
         .scroll-card-text {
             max-width: 60%;
             padding-left: 60px;
-        }
-
-        h2 {
-            font-size: 48px;
-        }
-
-        p {
-            font-size: 22px;
         }
     }
 
@@ -270,50 +233,5 @@ import ContentSvg from "@atoms/ContentSVG.astro";
             max-width: 60%;
             padding-left: 80px;
         }
-
-        h2 {
-            font-size: 60px;
-        }
-
-        p {
-            font-size: 28px;
-        }
     }
-
-    /* @media screen and (min-width: 37em) {
-        h1 {
-            font-size: 3em;
-        }
-        .scroll-cards__item {
-            --offset: 1em;
-            padding-left: 5em;
-        }
-        .scroll-cards__item:before {
-            counter-incremcroll-card;
-            content: "0" coucroll-card);
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            width: 2.75em;
-            height: 2.75em;
-            background: #f09;
-            color: #fff;
-            text-align: center;
-            border-radius: 50%;
-            position: absolute;
-            left: 1.25em;
-            top: 1.25em;
-            font-weight: bold;
-        }
-    }
-
-    @media screen and (min-width: 62em) {
-        .scroll-cards h1 {
-            font-size: 3em;
-        }
-        .scroll-cards__item {
-            --offset: 1.25em;
-            max-width: 42em;
-        }
-    } */
 </style>

--- a/src/components/molecules/Hero.astro
+++ b/src/components/molecules/Hero.astro
@@ -56,10 +56,10 @@ import Button from "@atoms/Button.astro";
         align-items: center;
         width: 100%;
         text-align: center;
+        container-type: inline-size;
     }
 
     h1 {
-        font-size: 48px;
         margin-top: clamp(4rem, 16vh, 10rem);
         line-height: 1;
     }
@@ -67,12 +67,9 @@ import Button from "@atoms/Button.astro";
     .hero-title-static-wrapper {
         display: flex;
         position: relative;
-        height: 1em;
-        overflow: hidden;
     }
 
     .hero-title-static {
-        width: 100%;
         animation: heroIntro 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
         animation-delay: 0.2s;
         opacity: 0;
@@ -101,15 +98,13 @@ import Button from "@atoms/Button.astro";
     .rotator-word {
         width: 100%;
         position: absolute;
-        font-weight: bold;
-        top: -0px;
-        animation: rotateWord 10s cubic-bezier(0.25, 0.46, 0.45, 0.94)
-            infinite both;
+        animation: rotateWord 10s cubic-bezier(0.25, 0.46, 0.45, 0.94) infinite
+            both;
         will-change: transform, opacity;
     }
 
     .rotator-word:nth-child(1) {
-        animation-delay: .26s;
+        animation-delay: 0.26s;
     }
     .rotator-word:nth-child(2) {
         animation-delay: 2.76s;
@@ -148,13 +143,11 @@ import Button from "@atoms/Button.astro";
     }
 
     p {
-        font-family: "Jetbrains", sans-serif;
-        font-size: 16px;
         margin-top: clamp(2rem, 16vh, 14rem);
-        line-height: 1.4;
         opacity: 0;
         animation: heroIntro 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
         animation-delay: 0.32s;
+        width: 95%;
     }
 
     .button-animation {
@@ -224,17 +217,7 @@ import Button from "@atoms/Button.astro";
         }
     }
 
-    @media screen and (min-width: 540px) {
-        h1 {
-            font-size: 72px;
-        }
-    }
-
     @media screen and (min-width: 768px) {
-        h1 {
-            font-size: 96px;
-        }
-
         .contact-button {
             font-weight: 700;
             margin: 36px auto 0;
@@ -248,29 +231,8 @@ import Button from "@atoms/Button.astro";
     }
 
     @media screen and (min-width: 1024px) {
-        h1 {
-            font-size: 128px;
-        }
-
         p {
             width: 70%;
-            font-size: 18px;
-            margin-top: clamp(2rem, 10vh, 14rem);
-        }
-    }
-
-    @media screen and (min-width: 1224px) {
-        .hero {
-            height: 75vh;
-        }
-
-        h1 {
-            font-size: 128px;
-        }
-
-        p {
-            width: 70%;
-            font-size: 18px;
             margin-top: clamp(2rem, 10vh, 14rem);
         }
     }

--- a/src/components/molecules/blogCard.astro
+++ b/src/components/molecules/blogCard.astro
@@ -32,7 +32,7 @@ console.log({ slug });
                     </ul>
                 )
             }
-            <h2 class="blog-card-title">{title}</h2>
+            <h5 class="blog-card-title">{title}</h5>
             <p class="blog-card-excerpt">{excerpt}</p>
 
             <div class="see-more">
@@ -57,18 +57,25 @@ console.log({ slug });
         transition: outline-offset 0.2s ease;
     }
 
+    h5 {
+        font-family: "Midnight", sans-serif;
+        text-transform: uppercase;
+    }
+    
+    p {
+        font-family: 'Inter', sans-serif;
+        font-size: 1rem;
+        line-height: 1.5;
+    }
+
     .blog-card-link:focus {
-       outline: none;
+        outline: none;
     }
 
     .blog-card-content {
         display: flex;
         flex-direction: column;
         padding: 25px;
-    }
-
-    .blog-card-content p {
-        line-height: 1.5;
     }
 
     .blog-card-title {

--- a/src/components/organisms/Faq.astro
+++ b/src/components/organisms/Faq.astro
@@ -44,7 +44,6 @@ import faqs from "@data/faqs.json";
     }
 
     .faq-title {
-        font-size: 48px;
         text-align: center;
         margin-bottom: 2rem;
     }
@@ -110,12 +109,6 @@ import faqs from "@data/faqs.json";
             justify-content: space-between;
         }
 
-        .faq-title {
-            font-size: 60px;
-            height: 100%;
-            line-height: 0.9;
-        }
-
         .faq-question {
             font-size: 20px;
             padding: 40px;
@@ -145,10 +138,6 @@ import faqs from "@data/faqs.json";
     @media screen and (min-width: 1024px) {
         .faq-section {
             padding: 400px 60px;
-        }
-
-        .faq-title {
-            font-size: 96px;
         }
 
         .faq-list {

--- a/src/components/organisms/Footer.astro
+++ b/src/components/organisms/Footer.astro
@@ -5,7 +5,7 @@ import Button from "@atoms/Button.astro"
 <section class="footer">
     <div class="footer-content">
         <div class="consult">
-            <h4>Plan een gratis consult</h4>
+            <h3>Plan een gratis consult</h3>
            <Button text="Contact" href="/contact"/>
         </div>
         <div class="footer-links">
@@ -59,9 +59,11 @@ import Button from "@atoms/Button.astro"
         text-decoration: underline;
     }
 
-    h4 {
-        font-size: 48px;
+    h3 {
+        font-family: 'Inter', sans-serif;
+        text-transform: none;
         font-weight: 400;
+        font-size: clamp(3rem, 3vw + 1rem, 5rem);
     }
 
     .contact-button {
@@ -123,10 +125,6 @@ import Button from "@atoms/Button.astro"
     @media screen and (min-width: 813px) {
         .footer {
             padding: 150px 60px 25px;
-        }
-
-        h4 {
-            font-size: 60px;
         }
 
         .footer-content {

--- a/src/pages/ai-agents.astro
+++ b/src/pages/ai-agents.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from "@layout/Layout.astro";
 import ArrowRight from "@atoms/ArrowRight.astro";
+import Button from "@atoms/Button.astro";
 
 const aiAgentsStructuredData = {
     "@context": "https://schema.org",
@@ -43,15 +44,14 @@ const aiAgentsStructuredData = {
     <section class="ai-agents-hero">
         <div class="hero-content">
             <h1>AI-agents</h1>
-            <h2>Jouw bedrijf op autopiloot met AI.</h2>
             <p class="hero-subtitle">
                 Automatiseer content, SEO en communicatie processen met AI,
                 zonder je merkidentiteit te verliezen met AI-agents die jouw
                 bedrijf écht begrijpen.
             </p>
-            <a href="/contact" class="cta-button"
-                tabindex="0">Gratis adviesgesprek <ArrowRight /></a
-            >
+            <Button text="Gratis analyse"
+                href="/contact"
+                animateTag="agents-cta"/>
         </div>
         <small
             >of <a href="#how-it-works"
@@ -62,7 +62,7 @@ const aiAgentsStructuredData = {
 
     <section class="how-it-works" id="how-it-works">
         <div class="section-container">
-            <h2>Hoe het werkt</h2>
+            <h4>Hoe het werkt</h4>
             <p class="section-intro">
                 Onze tools sluiten aan op je bestaande systemen en processen.
                 Geen gedoe. Geen leercurve. Gewoon een slimme uitbreiding van je
@@ -73,7 +73,7 @@ const aiAgentsStructuredData = {
                 <div class="step">
                     <div class="step-number">1</div>
                     <div class="step-content">
-                        <h3>Intake & analyse</h3>
+                        <h5>Intake & analyse</h5>
                         <p>
                             Gratis eerste gesprek en analyse van je huidige
                             content en bedrijfsprocessen.
@@ -83,7 +83,7 @@ const aiAgentsStructuredData = {
                 <div class="step">
                     <div class="step-number">2</div>
                     <div class="step-content">
-                        <h3>Maatwerk AI-workflow</h3>
+                        <h5>Maatwerk AI-workflow</h5>
                         <p>
                             We ontwikkelen een op maat gemaakte AI-workflow
                             specifiek voor jouw behoeften.
@@ -93,7 +93,7 @@ const aiAgentsStructuredData = {
                 <div class="step">
                     <div class="step-number">3</div>
                     <div class="step-content">
-                        <h3>Test & optimalisatie</h3>
+                        <h5>Test & optimalisatie</h5>
                         <p>
                             We testen de AI-agent grondig en optimaliseren deze
                             op basis van feedback.
@@ -103,7 +103,7 @@ const aiAgentsStructuredData = {
                 <div class="step">
                     <div class="step-number">4</div>
                     <div class="step-content">
-                        <h3>Live inzet & groei</h3>
+                        <h5>Live inzet & groei</h5>
                         <p>
                             De AI-agent gaat live en blijft zich ontwikkelen
                             naarmate je bedrijf groeit.
@@ -113,8 +113,6 @@ const aiAgentsStructuredData = {
             </div>
         </div>
         <svg
-            width="1077"
-            height="734"
             viewBox="0 0 1077 734"
             fill="none"
             xmlns="http://www.w3.org/2000/svg"
@@ -711,7 +709,7 @@ const aiAgentsStructuredData = {
                         <path d="M7 17h10"></path>
                     </svg>
                 </div>
-                <h3>AI-agents die jouw bedrijf écht begrijpen</h3>
+                <h5>AI-agents die jouw bedrijf écht begrijpen</h5>
                 <p>
                     Onze agents bootsen jouw bestaande contentstijl na en
                     optimaliseren deze, zodat jouw team sneller en consistenter
@@ -741,7 +739,7 @@ const aiAgentsStructuredData = {
                         <path d="m13.95 12.97 2.61 2.61"></path>
                     </svg>
                 </div>
-                <h3>Op maat gemaakte implementatie</h3>
+                <h5>Op maat gemaakte implementatie</h5>
                 <p>
                     We bouwen de agent in nauwe samenwerking, volledig afgestemd
                     op jouw wensen en bestaande bedrijfsprocessen.
@@ -770,7 +768,7 @@ const aiAgentsStructuredData = {
                         <path d="m12 12 7 7-7-7z"></path>
                     </svg>
                 </div>
-                <h3>Gratis eerste setup voor pilotklanten</h3>
+                <h5>Gratis eerste setup voor pilotklanten</h5>
                 <p>
                     De eerste setup is gratis voor pilotklanten, waardoor je
                     zonder risico kunt ervaren wat onze agents kunnen betekenen.
@@ -781,7 +779,7 @@ const aiAgentsStructuredData = {
 
     <section class="use-cases">
         <div class="section-container">
-            <h2 class="section-title">Onze AI-agents in act</h2>
+            <h4 class="section-title">Onze AI-agents in act</h4>
 
             <div class="case-grid">
                 <!-- Use Case 1 -->
@@ -804,7 +802,7 @@ const aiAgentsStructuredData = {
                                 ></path>
                             </svg>
                         </div>
-                        <h3>Social Content Agent</h3>
+                        <h5>Social Content Agent</h5>
                         <div class="case-tagline">
                             Jouw merkstem. Dagelijks zichtbaar. Volledig
                             geautomatiseerd.
@@ -848,7 +846,7 @@ const aiAgentsStructuredData = {
                                 ></path>
                             </svg>
                         </div>
-                        <h3>E-mail Automation Agent</h3>
+                        <h5>E-mail Automation Agent</h5>
                         <div class="case-tagline">
                             Reageert sneller dan je team, mét jouw toon.
                         </div>
@@ -898,7 +896,7 @@ const aiAgentsStructuredData = {
                                 ></path>
                             </svg>
                         </div>
-                        <h3>SEO Blog Agent</h3>
+                        <h5>SEO Blog Agent</h5>
                         <div class="case-tagline">
                             Blogposts die scoren in Google én klinken zoals jij.
                         </div>
@@ -928,7 +926,7 @@ const aiAgentsStructuredData = {
 
     <section class="cta-section">
         <div class="section-container">
-            <h2>Klaar voor de toekomst van content?</h2>
+            <h4>Klaar voor de toekomst van content?</h4>
             <p>
                 Plan nu een gratis consult en ontdek wat AI-agents voor jouw
                 bedrijf kunnen betekenen.
@@ -951,25 +949,18 @@ const aiAgentsStructuredData = {
     }
 
     .hero-content {
-        max-width: 900px;
+        /* max-width: 900px; */
         margin-bottom: 40px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
     }
 
     .ai-agents-hero h1 {
-        font-size: 48px;
         margin-bottom: 24px;
     }
 
-    .ai-agents-hero h2 {
-        font-size: 24px;
-        margin-bottom: 20px;
-        color: var(--dark-color);
-    }
-
     .hero-subtitle {
-        font-family: "Jetbrains", sans-serif;
-        font-size: 18px;
-        line-height: 1.6;
         margin-bottom: 40px;
         margin-top: clamp(2rem, 8vh, 14rem);
     }
@@ -1006,16 +997,12 @@ const aiAgentsStructuredData = {
         margin: 0 auto;
     }
 
-    section h2 {
-        font-size: 32px;
+    section h4 {
         margin-bottom: 24px;
     }
 
     .section-intro {
-        font-size: 18px;
-        line-height: 1.6;
         margin-bottom: 40px;
-        font-family: "Jetbrains", sans-serif;
     }
 
     /* Features section */
@@ -1059,15 +1046,8 @@ const aiAgentsStructuredData = {
         color: var(--dark-color);
     }
 
-    .feature-card h3 {
-        font-size: 20px;
+    .feature-card h5 {
         margin-bottom: 16px;
-        color: var(--dark-color);
-    }
-
-    .feature-card p {
-        font-family: "Jetbrains", sans-serif;
-        line-height: 1.6;
     }
 
     /* How it works section */
@@ -1106,16 +1086,10 @@ const aiAgentsStructuredData = {
         flex-shrink: 0;
     }
 
-    .step-content h3 {
-        font-size: 20px;
+    .step-content h5 {
         margin-bottom: 12px;
     }
-
-    .step-content p {
-        font-family: "Jetbrains", sans-serif;
-        line-height: 1.6;
-    }
-
+    
     .how-it-works svg {
         max-width: 600px;
         min-width: 330px;
@@ -1131,10 +1105,8 @@ const aiAgentsStructuredData = {
     }
 
     .section-title {
-        font-size: 2.5rem;
         text-align: center;
         margin-bottom: 64px;
-        font-weight: 700;
     }
 
     .case-grid {
@@ -1173,11 +1145,8 @@ const aiAgentsStructuredData = {
         height: 32px;
     }
 
-    h3 {
-        font-size: 1.5rem;
-        font-weight: 700;
+    h5 {
         margin-bottom: 16px;
-        color: #111827;
     }
 
     .case-tagline {
@@ -1189,7 +1158,6 @@ const aiAgentsStructuredData = {
     }
 
     .case-content p {
-        color: #4b5563;
         line-height: 1.6;
         margin-bottom: 16px;
     }
@@ -1227,49 +1195,17 @@ const aiAgentsStructuredData = {
         text-align: center;
     }
 
-    .cta-section h2 {
-        font-size: 36px;
+    .cta-section h4 {
         margin-bottom: 20px;
     }
 
     .cta-section p {
-        font-size: 18px;
         max-width: 600px;
         margin: 0 auto 40px;
-        font-family: "Jetbrains", sans-serif;
-    }
-
-    /* CTA button */
-    .cta-button {
-        display: inline-flex;
-        align-items: center;
-        gap: 8px;
-        background-color: var(--dark-color);
-        color: var(--light-color);
-        padding: 12px 24px;
-        border-radius: 8px;
-        font-weight: 600;
-        font-size: 16px;
-        transition: background-position 0.6s;
-        background-size: 300%;
-        background-image: linear-gradient(90deg, #3a6caa 50%, #facc15 50%);
-    }
-
-    .cta-button:hover {
-        color: #fff;
-        background-position: 100%;
     }
 
     /* Media queries */
     @media screen and (min-width: 640px) {
-        .ai-agents-hero h1 {
-            font-size: 60px;
-        }
-
-        .ai-agents-hero h2 {
-            font-size: 32px;
-        }
-
         .features-container {
             grid-template-columns: 1fr 1fr;
         }
@@ -1304,10 +1240,6 @@ const aiAgentsStructuredData = {
             padding: 0 60px;
         }
 
-        .ai-agents-hero h1 {
-            font-size: 72px;
-        }
-
         .steps {
             grid-template-columns: repeat(2, 1fr);
         }
@@ -1323,18 +1255,6 @@ const aiAgentsStructuredData = {
     }
 
     @media screen and (min-width: 1024px) {
-        .ai-agents-hero h1 {
-            font-size: 128px;
-        }
-
-        .ai-agents-hero h2 {
-            font-size: 40px;
-        }
-
-        .hero-subtitle {
-            font-size: 18px;
-        }
-
         .how-it-works {
             display: flex;
             flex-direction: row;
@@ -1342,18 +1262,6 @@ const aiAgentsStructuredData = {
 
         .features-container {
             grid-template-columns: repeat(3, 1fr);
-        }
-
-        section h2 {
-            font-size: 48px;
-        }
-
-        .section-title {
-            font-size: 3rem;
-        }
-
-        h3 {
-            font-size: 1.875rem;
         }
 
         .use-cases {
@@ -1387,7 +1295,7 @@ const aiAgentsStructuredData = {
         });
 
         gsap.from(
-            ".ai-agents-hero h2, .hero-subtitle, .ai-agents-hero .cta-button, .ai-agents-hero small",
+            ".ai-agents-hero h4, .hero-subtitle, .ai-agents-hero [animateTag='agents-cta'], .ai-agents-hero small",
             {
                 y: 30,
                 opacity: 0,

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -89,18 +89,8 @@ const blogStructuredData = {
         padding: 80px 25px 600px;
     }
 
-    h1 {
-        font-size: 48px;
-    }
-
-    h2 {
-        font-family: "JetBrains", sans-serif;
-    }
-
     p {
         padding-top: 24px;
-        line-height: 1.4;
-        font-family: "Jetbrains", sans-serif;
         padding-bottom: 80px;
     }
 
@@ -128,12 +118,6 @@ const blogStructuredData = {
         }
 
         h1 {
-            font-size: 72px;
-            text-align: center;
-        }
-
-        h2 {
-            font-size: 36px;
             text-align: center;
         }
 
@@ -143,21 +127,8 @@ const blogStructuredData = {
     }
 
     @media screen and (min-width: 1024px) {
-        h1 {
-            font-size: 128px;
-        }
-
-        h2 {
-            font-size: 64px;
-        }
-
         ul {
             grid-template-columns: repeat(2, 1fr);
-        }
-
-        p {
-            max-width: 1000px;
-            font-size: 18px;
         }
     }
 

--- a/src/pages/blogs/[slug].astro
+++ b/src/pages/blogs/[slug].astro
@@ -182,6 +182,9 @@ const blogStructuredData = {
 
   .blog-content-text :global(p) {
     margin-bottom: 1rem;
+    font-family: "Inter", sans-serif;
+    font-size: 1rem;
+    line-height: 1.5;
   }
 
   .blog-content-text :global(h2) {

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -120,10 +120,6 @@ const contactStructuredData = {
         padding: 80px 25px;
     }
 
-    h1 {
-        font-size: 48px;
-    }
-
     p {
         padding-top: 24px;
         line-height: 1.4;
@@ -194,19 +190,12 @@ const contactStructuredData = {
         margin-left: 14px;
     }
 
-    @media screen and (min-width: 540px) {
-        h1 {
-            font-size: 60px;
-        }
-    }
-
     @media screen and (min-width: 813px) {
         .contact {
             padding: 120px 60px;
         }
 
         h1 {
-            font-size: 72px;
             text-align: center;
         }
 
@@ -221,15 +210,6 @@ const contactStructuredData = {
     @media screen and (min-width: 1024px) {
         .contact {
             padding: 120px 60px;
-        }
-
-        h1 {
-            font-size: 128px;
-        }
-
-        p {
-            max-width: 1000px;
-            font-size: 18px;
         }
     }
 </style>

--- a/src/pages/projecten.astro
+++ b/src/pages/projecten.astro
@@ -114,14 +114,9 @@ const projectsStructuredData = {
         padding-bottom: 80px;
     }
 
-    h1 {
-        font-size: 40px;
-    }
-
     p {
         padding-top: 24px;
         line-height: 1.4;
-        font-family: "Jetbrains", sans-serif;
     }
 
     ol {
@@ -131,12 +126,6 @@ const projectsStructuredData = {
         gap: 90px;
         padding: 0;
         margin: 0;
-    }
-
-    @media screen and (min-width: 380px) {
-        h1 {
-            font-size: 48px;
-        }
     }
 
     @media screen and (min-width: 764px) {
@@ -162,7 +151,6 @@ const projectsStructuredData = {
         }
 
         h1 {
-            font-size: 72px;
             text-align: center;
         }
 
@@ -175,14 +163,9 @@ const projectsStructuredData = {
         .projecten {
             padding: 120px 60px 300px;
         }
-
-        h1 {
-            font-size: 128px;
-        }
-
+        
         p {
             max-width: 1000px;
-            font-size: 18px;
         }
 
         ol {
@@ -192,16 +175,7 @@ const projectsStructuredData = {
 
     @media screen and (min-width: 1224px) {
         .projecten {
-            padding: 180px 60px 300px;
-        }
-
-        h1 {
-            font-size: 128px;
-        }
-
-        p {
-            max-width: 1000px;
-            font-size: 18px;
+            /* padding: 180px 60px 300px; */
         }
 
         ol {


### PR DESCRIPTION
## What does this change?
 
 Instead of fixed font sizes based on screen width, I've replaced them with ```clamp``` so they can adjust based on the viewport width.
This is better because the design is more consistent and won't have big font size "jumps". It also saves a lot of code.
As you can see its less than 1/3 of the code it was before
 
I've added this in the global CSS and removed other inline text styling:

```css
h1 {
    font-size: clamp(2.5rem, 8.5vw + 1rem, 10rem);
}

h2 {
    font-size: clamp(2rem, 5.5vw + 1rem, 8rem);
}

h3 {
    font-size: clamp(1.5rem, 3vw + 1rem, 5rem);
}

h4 {
    font-size: clamp(2rem, 4vw + 1rem, 3rem);
}

h5 {
    font-size: clamp(1.5rem, 2.5vw + 1rem, 1.875rem);
}

p {
    font-size: clamp(1rem, .8vw + 0.875rem, 1.375rem);
    line-height: 1.4;
    font-family: "JetBrains", sans-serif;
    max-width: 1000px;
}

```
 
## How Has This Been Tested?
 
- [ ] User test
- [ ] Accessibility test
- [ ] Performance test
- [x] Responsive Design test
- [ ] Device test
- [x] Browser test
 
## Images

### Before

![Responsive-font-sizes-before-ezgif com-video-to-gif-converter-2](https://github.com/user-attachments/assets/0c07ffa0-04fc-4416-97f7-3e8d5a76b4ef)

### After

![Responsive-font-sizes-after-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/20d0c049-610f-449e-a23b-6216a14b3653)

 ### Browser test

I've tested on Safari, Firefox and Chrome and there are no issues.