### PR TITLE
fix(navigation): removed squircle styling on menu

### DIFF
--- a/src/components/organisms/Navigation.astro
+++ b/src/components/organisms/Navigation.astro
@@ -37,7 +37,7 @@ import Menu from "@molecules/Menu.astro";
         </label>
     </div>
 
-    <div class="squircle mobile-menu" aria-label="Hoofdmenu">
+    <div class="mobile-menu" aria-label="Hoofdmenu">
         <Menu />
     </div>
 </nav>
@@ -157,7 +157,7 @@ import Menu from "@molecules/Menu.astro";
         align-items: center;
         background: var(--medium-color);
         padding: 33px 22px 22px;
-        /* border-radius: 16px; */
+        border-radius: 16px;
         visibility: hidden;
         pointer-events: none;
         transition:


### PR DESCRIPTION
## What does this change?
 
 The squircle module didn't work on safari because the ```paint()``` 
property is not supported. I tried working around it and creating a fallback. This didn't work so I removed the styling on the menu. It's just for the button right now on supported browsers. 
 
<img width="1011" height="737" alt="Screenshot 2025-08-24 at 09 41 45" src="https://github.com/user-attachments/assets/6e810822-7b57-45eb-9951-dc9a3b6f0b41" />

## How Has This Been Tested?
 
- [ ] User test
- [ ] Accessibility test
- [ ] Performance test
- [ ] Responsive Design test
- [ ] Device test
- [x] Browser test

### Browser test

I've tested on Safari, Chrome and Firefox. It all seems to be back to normal now.
 
## Images
 
**Before**
<img width="688" height="62" alt="Screenshot 2025-08-23 at 14 52 42" src="https://github.com/user-attachments/assets/7d485a5d-9d0d-4102-9f99-60a48ba3e288" />

**After**

<img width="671" height="62" alt="Screenshot 2025-08-23 at 14 52 48" src="https://github.com/user-attachments/assets/cde9a1da-906e-4075-8eff-e2abafeab16b" />

 
## How to review
 
Check in Safari if the border-radius is showing.
